### PR TITLE
JobSystemのChunkをスライスによるインデックス操作に変更

### DIFF
--- a/ChunkAllocator.h
+++ b/ChunkAllocator.h
@@ -6,25 +6,30 @@ namespace ECS::JobSystem{
     // https://qiita.com/taqu/items/45ab4fb57e4079c3be94
     // Qiita‹LŽ–[Chunk allocator]
     // 
+    // 
+    
+    struct Chunk {
+        std::uint16_t next_{};
+        std::atomic<std::uint16_t> start{ 0 };
+        std::atomic<std::uint16_t> count{ 0 };
+        //std::vector<T, Capacity> tasks{};
+        bool full() const { return count.load(std::memory_order_acquire) == Capacity; }
+        bool empty() const { return count.load(std::memory_order_acquire) == 0; }
+
+        std::uint16_t remaining() const noexcept {
+            return count.load(std::memory_order_acquire)
+                - start.load(std::memory_order_acquire);
+        }
+    };
+
     //Capactity‚Í512‚Ü‚ÅŽw’è‰Â”\
     template <typename T, size_t Capacity, size_t ChunkCount, size_t Align = 16>
     class ChunkAllocator {
         using u16 = std::uint16_t;
 
-    public:
-        struct Chunk {
-            u16 next_{};
-            std::atomic<u16> start{ 0 };
-            std::atomic<u16> count{ 0 };
-            std::array<T, Capacity> tasks{};
-            bool full() const { return count.load(std::memory_order_acquire) == Capacity; }
-            bool empty() const { return count.load(std::memory_order_acquire) == 0; }
+    public
 
-            u16 remaining() const noexcept {
-                return count.load(std::memory_order_acquire)
-                    - start.load(std::memory_order_acquire);
-            }
-        };
+        
 
         struct ChunkDeleter {
             ChunkAllocator* alloc;
@@ -85,7 +90,6 @@ namespace ECS::JobSystem{
         }
 
         Chunk* allocate() {
-
             if (freeList_ == Invalid) {
                 return nullptr; // ‹ó‚«‚È‚µ
             }
@@ -152,4 +156,5 @@ namespace ECS::JobSystem{
 
         return handle;
     }
+
 }

--- a/JobDeque.hpp
+++ b/JobDeque.hpp
@@ -51,13 +51,13 @@ namespace ECS::JobSystem {
     class JobDeque {
 
     public:
-        using PushResult = std::pair<PushStatus, Chunk>;
+        using PushResult = std::pair<PushStatus, std::optional<Chunk>>;
 
-        using PopResult = std::pair<PopStatus, Chunk>;
+        using PopResult = std::pair<PopStatus, std::optional<Chunk>>;
 
-        using StealResult = std::pair<StealStatus, Chunk>;
+        using StealResult = std::pair<StealStatus, std::optional<Chunk>>;
 
-        explicit JobDeque(size_t capacity,size_t index,JobDeque<Chunk>*)
+        explicit JobDeque(size_t capacity,size_t index)
             : bottom(0),
             top(0),
             capacity(capacity),
@@ -76,13 +76,21 @@ namespace ECS::JobSystem {
         JobDeque(JobDeque&&) noexcept = default; //ムーブのみOK
         JobDeque& operator=(JobDeque&&) noexcept = default;
 
-        template<typename TaskQ>
-        bool pushWithTimeout(Chunk& chunk,TaskQ&taskQ,std::chrono::milliseconds timeout = std::chrono::milliseconds{ 2 });
+        size_t remainingSlot(){
+            size_t curSize = unsafe_size();
+            return curSize < capacity ? capacity - curSize : 0;
+        }
 
-        PopStatus popQueue(Chunk& chunk);
+        template<typename TaskQ>
+        bool pushWithTimeout(Chunk&& chunk,TaskQ&taskQ,std::chrono::milliseconds timeout = std::chrono::milliseconds{ 2 });
 
         template<typename JobQueue>
-        StealStatus stealQueues(Chunk& chunk, JobQueue* stealQueues);
+        bool popOrSteal(JobQueue* stealQueues,Chunk&chunk);
+
+        PopStatus pop(Chunk& chunk);
+
+        template<typename JobQueue>
+        StealStatus steal(JobQueue* queues, Chunk& chunk);
 
         //オーナースレッド専用：ボトムからPush
         PushResult pushBottom(Chunk chunk) {
@@ -112,7 +120,7 @@ namespace ECS::JobSystem {
             const std::string log = "PUSH in Queue : " + getQueueIndex();
             checkInvariant(log.c_str());
 
-            return { PushStatus::Success,nullptr};
+            return { PushStatus::Success,std::nullopt };
         }
 
         bool empty() const {
@@ -121,9 +129,8 @@ namespace ECS::JobSystem {
             return t >= b;
         }
 
-        //デバッグ用にのみ。
         size_t unsafe_size() const {
-            return bottom - top.load();
+            return bottom.load() - top.load();
         }
 
         //Jobがまだスロット内に残っているかチェックし、ある場合ログとして出力
@@ -132,7 +139,7 @@ namespace ECS::JobSystem {
 
             for (size_t i = 0; i < capacity; i++)
             {
-                if(slotData[i]!=nullptr){
+                if(slotData[i]!= std::nullopt){
                     validSlots.push_back(i);
                 }
             }
@@ -180,7 +187,7 @@ namespace ECS::JobSystem {
             size_t b0 = bottom.load(std::memory_order_seq_cst);
             size_t t0 = top.load(std::memory_order_seq_cst);
             if (b0 <= t0) {
-                return { PopStatus::Empty, nullptr };
+                return { PopStatus::Empty, std::nullopt };
             }
 
             //取り出し候補位置
@@ -190,10 +197,10 @@ namespace ECS::JobSystem {
             //スロットロック＋中身チェック
             std::unique_lock lk(slotMutex[idx], std::try_to_lock);
             if (!lk.owns_lock()) {
-                return { PopStatus::WouldBlock, nullptr };
+                return { PopStatus::WouldBlock, std::nullopt };
             }
-            if (slotData[idx] == nullptr) {
-                return { PopStatus::Empty, nullptr };
+            if (slotData[idx] == std::nullopt) {
+                return { PopStatus::Empty, std::nullopt };
             }
 
             //最後の１要素
@@ -201,7 +208,7 @@ namespace ECS::JobSystem {
                 size_t curTop = top.load(std::memory_order_acquire);
                 if (curTop != t0) {
                     bottom.store(curTop, std::memory_order_release);
-                    return { PopStatus::Empty, nullptr };
+                    return { PopStatus::Empty, std::nullopt };
                 }
 
                 size_t expected = t0;
@@ -214,19 +221,19 @@ namespace ECS::JobSystem {
                     //steal側が勝利 → bottomはそのままEmpty扱い
                     const std::string log = "POP LAST FAIL in Queue : " + std::to_string(getQueueIndex());
                     checkInvariant(log.c_str());
-                    return { PopStatus::Empty, nullptr };
+                    return { PopStatus::Empty, std::nullopt };
                 }
 
                 //基本この分岐を通る。
-                Chunk result = std::move(slotData[idx]);
-                slotData[idx] = nullptr;
+                Chunk result = std::move(*slotData[idx]);
+                slotData[idx] = std::nullopt;
                 bottom.store(t0 + 1, std::memory_order_release);
                 const std::string msg = "POP LAST OK in " + std::to_string(getQueueIndex());
                 checkInvariant(msg.c_str());
                 return { PopStatus::Success, std::move(result) };
             }
 
-            Chunk result = std::move(slotData[idx]);
+            Chunk result = std::move(*slotData[idx]);
             slotData[idx] = nullptr;
             bottom.fetch_sub(1, std::memory_order_release);
             const std::string nlog = "POP NORMAL OK in Queue : " + std::to_string(getQueueIndex());
@@ -241,7 +248,7 @@ namespace ECS::JobSystem {
             size_t t0 = top.load(std::memory_order_seq_cst);
             size_t b0 = bottom.load(std::memory_order_seq_cst);
             if (t0 >= b0) {
-                return { StealStatus::Empty, nullptr };
+                return { StealStatus::Empty, std::nullopt };
             }
 
             size_t idx = t0 & mask;
@@ -250,15 +257,15 @@ namespace ECS::JobSystem {
             //念のため、steal専用のロックも行う
             std::unique_lock tailLk(stealMutex, std::try_to_lock);
             if (!tailLk.owns_lock()) {
-                return { StealStatus::WouldBlock, nullptr };
+                return { StealStatus::WouldBlock, std::nullopt };
             }
 
             std::unique_lock lk(slotMutex[idx], std::try_to_lock);
             if (!lk.owns_lock()) {
-                return { StealStatus::WouldBlock, nullptr };
+                return { StealStatus::WouldBlock, std::nullopt };
             }
-            if (slotData[idx] == nullptr) {
-                return { StealStatus::Empty, nullptr };
+            if (slotData[idx] == std::nullopt) {
+                return { StealStatus::Empty, std::nullopt };
             }
 
             //最後の1要素
@@ -271,13 +278,13 @@ namespace ECS::JobSystem {
                 //Steal失敗
                 const std::string log = "STEAL FAIL of Queue : " + std::to_string(index);
                 checkInvariant(log.c_str());
-                return { StealStatus::Empty, nullptr };
+                return { StealStatus::Empty, std::nullopt };
             }
 
             //基本、この分岐を通る。
-            Chunk result = std::move(slotData[idx]);
+            Chunk result = std::move(*slotData[idx]);
             //対象のスロットリセット
-            slotData[idx] = nullptr;
+            slotData[idx] = std::nullopt;
 
             const std::string slog = "STEAL SUCCESS of Queue : " + std::to_string(index);
             checkInvariant(slog.c_str());
@@ -325,7 +332,7 @@ namespace ECS::JobSystem {
 
         std::vector<std::mutex>        slotMutex;
         std::mutex stealMutex;
-        std::vector<Chunk>  slotData;
+        std::vector<std::optional<Chunk>>  slotData;
 
         // インデックス管理
         std::atomic<size_t> top;     // スティーラーが進める
@@ -339,7 +346,7 @@ namespace ECS::JobSystem {
     };
 
     template<typename Chunk>
-    inline PopStatus JobDeque<Chunk>::popQueue(Chunk& chunk)
+    inline PopStatus JobDeque<Chunk>::pop(Chunk& chunk)
     {
         auto popRes = popBottom();
 
@@ -356,12 +363,14 @@ namespace ECS::JobSystem {
 
     template<typename Chunk>
     template<typename TaskQ>
-    inline bool JobDeque<Chunk>::pushWithTimeout(Chunk& chunk, TaskQ& taskQ, std::chrono::milliseconds timeout)
+    inline bool JobDeque<Chunk>::pushWithTimeout(Chunk&& chunk, TaskQ& taskQ, std::chrono::milliseconds timeout)
     {
-        auto start = std::chrono::steady_clock::now();
+        auto start = std::chrono::steady_clock::now(); 
+
+        auto c = std::move(chunk);
 
         while (true) {
-            auto [status, notPushed] = pushBottom(std::move(chunk));
+            auto [status, notPushed] = pushBottom(std::move(c));
 
             if(status == PushStatus::Success){
                 return true;
@@ -375,7 +384,7 @@ namespace ECS::JobSystem {
             }
 
             //少し待って再挑戦
-            chunk = std::move(notPushed);
+            c = std::move(notPushed);
             std::this_thread::yield();
             continue;
         }
@@ -385,14 +394,42 @@ namespace ECS::JobSystem {
 
     template<typename Chunk>
     template<typename JobQueue>
-    inline StealStatus JobDeque<Chunk>::stealQueues(Chunk& chunk, JobQueue* stealQueues)
+    inline bool JobDeque<Chunk>::popOrSteal(JobQueue* stealQueues, Chunk& chunk)
     {
-        size_t n = stealQueues.size();
+        //自キューからPOP
+        {
+            auto popRes = pop(chunk);
+        
+            if (popRes == PopStatus::Success) {
+                return true;
+            }
+            else if (popRes == PopStatus::WouldBlock) {
+                std::this_thread::yield();
+                return true;
+            }
+        }
+        
+        //他キューからSteal
+        {
+            auto result = steal(stealQueues,chunk);
+            if (result == StealStatus::Success) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    template<typename Chunk>
+    template<typename JobQueue>
+    inline StealStatus JobDeque<Chunk>::steal(JobQueue* queues, Chunk& chunk)
+    {
+        size_t n = queues.size();
 
         StealResult result;
         for (size_t i = 1; i < n; ++i) {
             size_t idx = (queueIndex + i) % n;
-            result = stealQueues[idx]->stealTop(queueIndex);
+            result = queues[idx]->stealTop(queueIndex);
 
             if (result.first == StealStatus::Success) {
                 chunk = std::move(result.second);

--- a/JobManager.cpp
+++ b/JobManager.cpp
@@ -14,136 +14,32 @@ void JobManager::Initialize(size_t threadCount, std::unique_ptr<TimelineRecorder
     nextQueue = 0;
     threadSize = threadCount;
 
-    outstanding = 0;
-
-    realTimeJobCounter = 0;
-    backGroundCounter = 0;
-
-    allocator = std::make_unique<ChunkAllocator>();
-
-    realTimeWaitQueues.reserve(threadCount);
-    backGroundWaitQueues.reserve(threadCount);
-    realTimeLocalQueue.reserve(threadCount);
-
+    localQueues.reserve(threadCount);
     //初期化
     for (size_t i = 0; i < threadCount; ++i) {
-        realTimeWaitQueues.push_back(std::make_unique<WaitBuf>(allocator.get()));
-        backGroundWaitQueues.push_back(std::make_unique<WaitBuf>(allocator.get()));
-        realTimeLocalQueue.emplace_back(
-            std::make_unique<JobQueue>(capacity, i)
-        );
-
-        backGroundLocalQueue.emplace_back(
-            std::make_unique<JobQueue>(capacity, i)
-        );
+       localQueues.emplace_back(std::make_unique<JobQueue>(capacity,i));
     }
 
-    // workers 初期化
     workers.reserve(threadCount);
     for (size_t i = 0; i < threadCount; ++i) {
-        workers.emplace_back([this, i]() noexcept {
-
-            this->workerThreadFunction(i);
-            });
+        workers.emplace_back(std::make_unique<RealTimeOnlyWorker>(i,localQueues.data(), stats_));
     }
+
 }
 JobManager::~JobManager()
 {
     if (!initFlag)return;
-
-    stopFlag.store(true, std::memory_order_relaxed);
-    {
-        std::lock_guard<std::mutex> lk(wakeMutex);
-        wakeCv.notify_all();           // ワーカー全員を起こす
-    }
-
-    for (auto& w : workers) {
-        if (w.joinable())
-            w.join();
-    }
-}
-void JobManager::waitForAll()
-{
-    std::unique_lock<std::mutex> lk(finishMutex);
-    finishCv.wait(lk, [&] {
-        return abortFlag.load(std::memory_order_acquire)
-            || outstanding.load(std::memory_order_acquire) == 0;
-        });
-}
-
-void JobManager::waitForAllRealTimeJob()
-{
-    std::unique_lock<std::mutex> lk(realTimeJob_Mutex);
-
-    realTimeJob_WaitCv.wait(lk, [&] {
-        return abortFlag.load(std::memory_order_acquire)
-            || realTimeJobCounter.load(std::memory_order_acquire) == 0;
-        });
-}
-
-void JobManager::waitForLocalBackGroundJob()
-{
-    std::unique_lock<std::mutex> lk(backGroundJob_Mutex);
-
-    backGroundJob_WaitCv.wait(lk, [&] {
-        return abortFlag.load(std::memory_order_acquire)
-            || backGroundCounter.load(std::memory_order_acquire) == 0;
-        });
-}
-
-void JobManager::workerThreadFunction(size_t queueIndex)
-{
-    const size_t index = queueIndex;
-    // 終了フラグと outstanding の組み合わせでループ制御
-    while (true) {
-        //停止指示または未完了ジョブなしなら抜ける
-        if (abortFlag.load(std::memory_order_acquire)) {
-            break;
-        }
-
-        if (stopFlag.load(std::memory_order_acquire) &&
-            outstanding.load(std::memory_order_acquire) == 0)
-        {
-            break;
-        }
-
-        run_realTimeQueue(queueIndex);
-
-        if (realTimeLocalQueue[index]->isAbort()||backGroundLocalQueue[index]->isAbort()) {
-            abort();
-            return;
-        }
-    }
-
-    if (abortFlag.load(std::memory_order_acquire)) {
-        run_while_validQueue(index);
-    }
 }
 
 bool JobManager::checkRanAllJobInJobQueues()
 {
-    for (auto& queue : realTimeLocalQueue) {
+    for (auto& queue : localQueues) {
         if (queue->validCheck()) {
             return false;
         }
     }
 
     return true;
-}
-
-void JobManager::pushJobWaitQueue(TaskPtr task)
-{
-    switch (task->category)
-    {
-    case JobCategory::RealTime:
-        pushRealTimeJobWaitQueue(std::move(task));
-        break;
-    case JobCategory::BackGround:
-        pushBackGroudGlobalQueue(std::move(task));
-        break;
-    default:
-        break;
-    }
 }
 
 //TaskPtr JobManager::pushJobWaitQueue(Job&& job, int degree, JobCategory cat)
@@ -174,122 +70,6 @@ std::chrono::steady_clock::time_point JobManager::getStartFrameTime() const
     return frameStart;
 }
 
-void JobManager::pushRealTimeJobWaitQueue(TaskPtr task)
-{
-    //カウンター処理
-    outstanding.fetch_add(1, std::memory_order_acq_rel);
-    realTimeJobCounter.fetch_add(1, std::memory_order_acq_rel);
-
-    size_t idx = getNextQueueIndex();
-    realTimeWaitQueues[idx]->push(task);
-
-    realTimeJob_WaitCv.notify_one();
-}
-
-void JobManager::pushBackGroudGlobalQueue(TaskPtr task)
-{
-    //カウンタ処理
-    outstanding.fetch_add(1, std::memory_order_acq_rel);
-
-    std::lock_guard<std::mutex>lk(backGroundMutex);
-
-    if (globalBackGroudQueue.capacity() < globalBackGroudQueue.size() + 1) {
-        globalBackGroudQueue.reserve(globalBackGroudQueue.size() + 16); 
-    }
-    
-    globalBackGroudQueue.push_back(std::move(task));
-}
-
-void JobManager::pushBackGroudGlobalQueue(std::vector<TaskPtr>&& tasks)
-{
-    const size_t size = tasks.size();
-
-    // タスク数を加算
-    outstanding.fetch_add(size, std::memory_order_acq_rel);
-    backGroundCounter.fetch_add(size, std::memory_order_acq_rel);
-
-    std::lock_guard<std::mutex>lk(backGroundMutex);
-
-    globalBackGroudQueue.reserve(globalBackGroudQueue.size() + size);
-
-    // move で一括挿入
-    globalBackGroudQueue.insert(globalBackGroudQueue.end(),
-        std::make_move_iterator(tasks.begin()),
-        std::make_move_iterator(tasks.end()));
-}
-
-bool JobManager::pushBottom(ChunkPtr&& chunkPtr, std::unique_ptr<JobQueue>& localQueue, std::unique_ptr<WaitBuf>& waitQueue)
-{
-    auto start = std::chrono::steady_clock::now();
-    const auto  timeout = std::chrono::milliseconds(2);
-
-    auto& queue = localQueue;
-    auto& waitQ = waitQueue;
-
-    while (true) {
-        PushResult res = queue->pushBottom(std::move(chunkPtr));
-
-        switch (res.first) {
-            case PushStatus::Success:
-            {
-                return true;
-            }
-
-            case PushStatus::WouldBlock:
-            {
-                if (std::chrono::steady_clock::now() - start >= timeout) {
-                    fallbackWaitQueue(waitQ, std::move(res.second));
-                    return false;
-                }
-
-                chunkPtr = std::move(res.second);
-                // 軽めのバックオフ
-                std::this_thread::yield();
-                break;
-            }
-            case PushStatus::Full:
-            {
-                if (std::chrono::steady_clock::now() - start < timeout) {
-                    chunkPtr = std::move(res.second);
-                    //少し待って再挑戦
-                    std::this_thread::yield();
-                }
-                else {
-                    fallbackWaitQueue(waitQ, std::move(res.second));
-                    return false;
-                }
-
-                break;
-            }
-        }
-
-    }
-}
-
-void JobManager::pushLocalQueue(std::unique_ptr<JobQueue>& localQueue, std::unique_ptr<WaitBuf>& waitQueue)
-{
-
-    ChunkPtr chunkPtr;
-    while (true) {
-        if(!waitQueue->try_pop(chunkPtr)){
-            break;
-        }
-
-        pushBottom(std::move(chunkPtr), localQueue, waitQueue);
-    }
-}
-
-std::optional<TaskPtr> JobManager::try_popGlobalBackGroundQueue()
-{
-    std::lock_guard<std::mutex>lock(backGroundMutex);
-
-    if (globalBackGroudQueue.empty()) return std::nullopt;
-
-    auto t = std::move(globalBackGroudQueue.back());
-    globalBackGroudQueue.pop_back();
-    return t;
-}
-
 void JobManager::popGlobalBackGroundQueue() {
     if (globalBackGroudQueue.empty()) return; // グローバルキューが空の場合終了
 
@@ -307,228 +87,45 @@ void JobManager::popGlobalBackGroundQueue() {
 
     size_t rawJobs = popBGNum / getThreadSize(); //一つのワーカーの処理するジョブ数
 
-    backGroundCounter.fetch_add(popBGNum, std::memory_order_acq_rel);
+    //backGroundCounter.fetch_add(popBGNum, std::memory_order_acq_rel);
 
     //繰り上げ分入れるために最後を除いたワーカー分、まずはpopする
     size_t workerNum = getThreadSize() - 1;
 
-    for (size_t t = 0; t < workerNum; ++t) {
-        //chunk
-        for(int j = 0; j < rawJobs;j++){
-            if (auto task = try_popGlobalBackGroundQueue()) {
-                // グローバルから取り出して各待機キューに割り当て
-                backGroundWaitQueues[t]->push(std::move(*task));
-            }
-            else {
-                return; // グローバルキューが空になった場合終了
-            }
-        }
-    }
+    ASSERT(false,"BackGroundJOb not work");
+
+    //for (size_t t = 0; t < workerNum; ++t) {
+    //    //chunk
+    //    for(int j = 0; j < rawJobs;j++){
+    //        if (auto task = try_popGlobalBackGroundQueue()) {
+    //            // グローバルから取り出して各待機キューに割り当て
+    //            workers[t]->schedule(JobCategory::BackGround,std::move(*task));
+    //        }
+    //        else {
+    //            return; // グローバルキューが空になった場合終了
+    //        }
+    //    }
+    //}
 
     // 最後の分は繰り上げ分入れる
-    auto lastPopNum = popBGNum - (rawJobs * workerNum);
-    
-    // 最後だけ
-    for(int i = 0;i < lastPopNum;i++){
-        // chunk分
-        if (auto task = try_popGlobalBackGroundQueue()) {
-            // グローバルから取り出す
-            backGroundWaitQueues[workerNum]->push(std::move(*task));
-        }
-        else {
-            return; // グローバルキューが空になった場合終了
-        }
-    }   
-}
-
-void JobManager::run_realTimeQueue(size_t queueIndex)
-{
-    pushLocalQueue(realTimeLocalQueue[queueIndex], realTimeWaitQueues[queueIndex]);
-
-    if(realTimeJobCounter == 0||
-        !pop_and_steal_Queue(
-        queueIndex
-        ,realTimeLocalQueue
-        , [&]() { sub_realTimeJob_counter();}) 
-        && !realTimeLocalQueue[queueIndex]->isAbort()){
-
-        pushLocalQueue(backGroundLocalQueue[queueIndex], backGroundWaitQueues[queueIndex]);
-
-        pop_and_steal_Queue(
-            queueIndex
-            , backGroundLocalQueue
-            , [&]() { sub_backGroundJob_counter();//カウンタ処理
-            });
-    }
-}
-
-void JobManager::run_backGroundQueue(size_t queueIndex)
-{
-    pushLocalQueue(backGroundLocalQueue[queueIndex], backGroundWaitQueues[queueIndex]);
-
-    if (!pop_and_steal_Queue(queueIndex, backGroundLocalQueue, [&]() {
-        sub_backGroundJob_counter(); 
-        })) {
-        pushLocalQueue(realTimeLocalQueue[queueIndex], realTimeWaitQueues[queueIndex]);
-
-        pop_and_steal_Queue(queueIndex, realTimeLocalQueue, [&]() {
-            sub_realTimeJob_counter();  // リアルタイム用カウンタ処理
-            });
-    }
-}
-
-bool JobManager::pop_and_steal_Queue(size_t queueIndex, std::vector<std::unique_ptr<JobQueue>>& queues, std::function<void()> sub_counterFunc)
-{
-    //リアルタイムJobを処理
-    //自キューからPOP
-    {
-        auto popRes = popBottom(queueIndex,queues[queueIndex]);
-
-        if (popRes == PopStatus::Success) {
-            sub_counterFunc();
-            return true;
-        }
-        else if (popRes == PopStatus::WouldBlock) {
-            std::this_thread::yield();
-            return true;
-        }
-    }
-
-    //他キューからSteal
-    {
-        auto stealRes = stealQueues(queueIndex, queues);
-
-        if (stealRes == StealStatus::Success) {
-            sub_counterFunc();
-            return true;
-        }
-    }
-
-    std::this_thread::yield();
-    return false;
-}
-
-PopStatus JobManager::popBottom(size_t queueIndex, std::unique_ptr<JobQueue>& queue)
-{
-    ChunkPtr chunk;
-    auto popRes = queue->popQueue(chunk);
-
-    if (popRes == PopStatus::Success) {
-        runChunk(queueIndex, std::move(chunk));
-    }
-
-    return popRes;
-}
-
-StealStatus JobManager::stealQueues(size_t queueIndex, std::vector<std::unique_ptr<JobQueue>>& stealQueues)
-{
-    ChunkPtr chunk;
-    auto result = stealQueues[queueIndex]->stealQueues(chunk,stealQueues);
-
-    if (result == StealStatus::Success) {
-        runChunk(queueIndex, std::move(chunk));
-    }
-
-    return result;
-}
-
-void JobManager::runChunk(size_t queueIndex, ChunkPtr&& chunkPtr)
-{
-    ASSERT(chunkPtr, "chunkPtr is nullptr!!");
-
-    while (true) {
-        auto idx = chunkPtr->start.fetch_add(1, std::memory_order_acq_rel);
-        auto end = chunkPtr->count.load(std::memory_order_acquire);
-
-        if (idx >= end)
-            break; // 全部終わった
-
-        auto task = std::move(chunkPtr->tasks[idx]);
-        runJob(queueIndex, std::move(task));
-    }
-}
-
-void JobManager::runJob(size_t queueIndex, TaskPtr&& task)
-{
-    ASSERT(task && task->job.valid(), "task is invoked in JobQueue!!");
-
-    task->job.invoke();
-
-    //繋がっているchildの依存カウントを減らしていく
-    for (TaskPtr child = task->nextDependent; child; child = child->nextDependent) {
-        if (child->inDegree.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-            pushJobWaitQueue(child);
-        }
-    }
-
-    static std::mutex logMutex;
-
-    // runJob 内
-    auto prev = outstanding.fetch_sub(1, std::memory_order_acq_rel);
-    bool didAllFinish = (prev == 1);
-
-    if (didAllFinish) {
-        std::lock_guard<std::mutex> lk(finishMutex);
-        finishCv.notify_all();
-    }
-
-    {
-        std::lock_guard<std::mutex> lk2(logMutex);
-        if (didAllFinish) {
-            test::saveLog("[All FINISH] queue=%zu outstanding=%zu", queueIndex, outstanding.load());
-            std::printf("[All FINISH] queue=%zu outstanding=%zu \n", queueIndex, outstanding.load());
-        }
-        else {
-            test::saveLog("[FINISH] queue=%zu outstanding=%zu", queueIndex, outstanding.load());
-            std::printf("[FINISH] queue=%zu outstanding=%zu \n", queueIndex, outstanding.load());
-        }
-    }
-}
-
-void JobManager::run_while_validQueue(size_t queueIndex)
-{
-    ChunkPtr chunk;
-    //待機キュー内のJob処理
-    while (realTimeWaitQueues[queueIndex]->try_pop(chunk))
-    {
-        runChunk(queueIndex, std::move(chunk));
-    }
-
-    while (backGroundWaitQueues[queueIndex]->try_pop(chunk))
-    {
-        runChunk(queueIndex, std::move(chunk));
-    }
-
-    while (true) {
-        auto popRes = realTimeLocalQueue[queueIndex]->popBottom();
-
-        if (popRes.first == PopStatus::Success) {
-            runChunk(queueIndex, std::move(popRes.second));
-            continue;
-        }
-
-        if (popRes.first == PopStatus::Empty) {
-            break;
-        }
-    }
-
-    while (true) {
-        auto popRes = backGroundLocalQueue[queueIndex]->popBottom();
-
-        if (popRes.first == PopStatus::Success) {
-            runChunk(queueIndex, std::move(popRes.second));
-            continue;
-        }
-
-        if (popRes.first == PopStatus::Empty) {
-            break;
-        }
-    }
+    //auto lastPopNum = popBGNum - (rawJobs * workerNum);
+    //
+    //// 最後だけ
+    //for(int i = 0;i < lastPopNum;i++){
+    //    // chunk分
+    //    if (auto task = try_popGlobalBackGroundQueue()) {
+    //        // グローバルから取り出す
+    //        workers[workerNum]->schedule(JobCategory::BackGround, std::move(*task));
+    //    }
+    //    else {
+    //        return; // グローバルキューが空になった場合終了
+    //    }
+    //}   
 }
 
 bool JobManager::allQueuesEmpty() const
 {
-    for (auto& dq : realTimeLocalQueue)
+    for (auto& dq : localQueues)
         if (!dq->empty()) return false;
     return true;
 }
@@ -544,7 +141,7 @@ void JobManager::abort()
 
 size_t JobManager::getNextQueueIndex()
 {
-    return nextQueue.fetch_add(1, std::memory_order_relaxed) % realTimeWaitQueues.size();
+    return nextQueue.fetch_add(1, std::memory_order_relaxed) % localQueues.size();
 }
 
 size_t JobManager::calculatePOPBGJobs(double target_ms, double elapsed_ms,double avgJobTime) {
@@ -555,19 +152,6 @@ size_t JobManager::calculatePOPBGJobs(double target_ms, double elapsed_ms,double
     if (remaining_ms <= safetyMarginMs||remaining_ms <= avgJobTime) return 0.0; // 十分な残り時間がない場合終了
 
     return static_cast<size_t>(std::min(std::floor(remaining_ms / avgJobTime), static_cast<double>(globalBackGroudQueue.size())));
-}
-
-void JobManager::sub_realTimeJob_counter()
-{
-    if (realTimeJobCounter.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        std::lock_guard<std::mutex> lk(realTimeJob_Mutex);
-        realTimeJob_WaitCv.notify_all();
-    }
-}
-
-void JobManager::sub_backGroundJob_counter()
-{
-    backGroundCounter.fetch_sub(1, std::memory_order_acq_rel);
 }
 
 }//namespace ECS::JobSystem

--- a/JobManager.h
+++ b/JobManager.h
@@ -15,42 +15,105 @@
 #include "JobBarrier.h"
 #include "JobDebugger.h"
 #include "TaskQueue.h"
-#include "ChunkAllocator.h"
+#include "taskPtr.hpp"
+#include "JobWorker.h"
 
 namespace ECS::JobSystem{
 
+    static constexpr size_t NumCategories = static_cast<size_t>(JobCategory::Num);
+
+    /// <summary>
+    /*pending	キューに積まれ、まだ取得・実行が始まっていないジョブ数	pushBottom() 後、popOrSteal() 前
+      running	ワーカーが取得し、現在実行中のジョブ数   popOrSteal() 成功直後 ～ 完了まで
+      completed	実行が終わり、後片付けや結果格納も含めて完了したジョブ数	runChunk / runJob() 実行後*/
+    /// </summary>
+    struct JobStats {
+
+        size_t pendingJobCount(const JobCategory cat) const noexcept{
+            return pending_[size_t(cat)].load(std::memory_order_acquire);
+        }
+
+        size_t runningJobCount(const JobCategory cat) const noexcept {
+            return running_[size_t(cat)].load(std::memory_order_acquire);
+        }
+
+        size_t completedJobCount(const JobCategory cat) const noexcept {
+            return completed_[size_t(cat)].load(std::memory_order_acquire);
+        }
+
+        size_t notCompletedJobCount(const JobCategory cat)const noexcept{
+            return pending_[size_t(cat)].load(std::memory_order_acquire) + running_[size_t(cat)].load(std::memory_order_acquire);
+        }
+
+        // pending の増減
+        void onEnqueued(const JobCategory cat,size_t count) noexcept {
+            pending_[size_t(cat)].fetch_add(1, std::memory_order_relaxed);
+        }
+
+        void onDequeued(const JobCategory cat,size_t count) noexcept {
+            pending_[size_t(cat)].fetch_sub(1, std::memory_order_relaxed);
+        }
+
+        // running の増減
+        void onStart(const JobCategory cat,size_t count) noexcept {
+            running_[size_t(cat)].fetch_add(1, std::memory_order_relaxed);
+        }
+        void onFinish(const JobCategory cat,size_t count) noexcept {
+            running_[size_t(cat)].fetch_sub(1, std::memory_order_relaxed);
+            completed_[size_t(cat)].fetch_add(1, std::memory_order_relaxed);
+
+            // pending + running が 0 なら全完了を通知
+            if (pending_[size_t(cat)].load(std::memory_order_acquire) == 0 &&
+                running_[size_t(cat)].load(std::memory_order_acquire) == 0)
+            {
+                std::lock_guard<std::mutex> lk(mtx_);
+                cv_.notify_all();
+            }
+        }
+
+        // フレーム終端で指定カテゴリがすべて完了するまで待つ
+        void waitForAll(const JobCategory cat) {
+            std::unique_lock<std::mutex> lk(mtx_);
+            cv_.wait(lk, [&] {
+                return pending_[size_t(cat)].load(std::memory_order_acquire) == 0
+                    && running_[size_t(cat)].load(std::memory_order_acquire) == 0;
+                });
+        }
+
+        void resetCompleted() noexcept {
+            for (auto& f : completed_)    f.store(0);
+        }
+
+        private:
+        // 各状態のカテゴリ別カウンタ
+        std::array<std::atomic<size_t>, NumCategories> pending_{};
+        std::array<std::atomic<size_t>, NumCategories> running_{};
+        std::array<std::atomic<size_t>, NumCategories> completed_{};
+
+        // フレーム同期用
+        std::mutex             mtx_;
+        std::condition_variable cv_;
+    };
+
+
 class JobManager
 {
-    struct Task;
-
-    template<typename T>
-    class intrusive_ptr;
+    /*template<typename T>
+    class intrusive_ptr;*/
 
     using TaskPtr = intrusive_ptr<Task>;
 
     static constexpr size_t bufferCap = 20'000;
 
-    //Chunkに詰められるTaskの最大数
-    static constexpr size_t ChunkCap = 512;
-
-    //1回の確保でまとめて作るchunkの数
-    static constexpr size_t ChunkMemSize = 14;
-
-    using ChunkAllocator = ChunkAllocator<TaskPtr, ChunkCap, ChunkMemSize,16>;
-
-    using Chunk = ChunkAllocator::Chunk;
-
-    using ChunkPtr = ChunkAllocator::ChunkHandle;
-
-    using WaitBuf = TaskQueue<TaskPtr,bufferCap,ChunkAllocator>;
-
-    using JobQueue = Debug::DebugJobQueue<JobDeque<ChunkPtr>>;
+    using JobQueue = Debug::DebugJobQueue<JobDeque<SliceChunk>>;
 
     using StealResult = JobQueue::Base::StealResult;
 
     using PopResult = JobQueue::Base::PopResult;
 
     using PushResult = JobQueue::Base::PushResult;
+
+    using RealTimeOnlyWorker = Worker<RealTimePolicy,JobExecutor>;
 
     //仮として60FPS
     static constexpr float targetFPS = 60.0f;
@@ -144,6 +207,7 @@ public:
 
         if (t->inDegree.load() == 0) {
             pushRealTimeJobWaitQueue(t);
+            
         }
 
         return std::make_pair(
@@ -186,13 +250,48 @@ public:
         return schedule_job(std::move(wrapped), deps);
     }
 
-    void waitForAll();
+    auto scheduleTask(TaskPtr task) {
+        size_t index = getNextQueueIndex();
 
-    void waitForAllRealTimeJob();
+        if (task->category == JobCategory::BackGround) {
+            ASSERT(false, "BackGroundJob not work");
+            //pushBackGroudGlobalQueue(std::move(task));
+        }
 
-    void waitForLocalBackGroundJob();
+        return workers[index]->schedule(task->category,std::move(task));
+    }
 
-    void workerThreadFunction(size_t queueIndex);
+    auto scheduleTask(JobCategory cat,Job&&job,int degree){
+        size_t index = getNextQueueIndex();
+
+        if(cat == JobCategory::BackGround){
+            ASSERT(false,"BackGroundJob not work");
+            //pushBackGroudGlobalQueue(std::move(task));
+        }
+
+        return workers[index]->schedule(cat, std::move(job), degree);
+    }
+
+    size_t getPendingJobCount(const JobCategory cat) const noexcept{
+        return stats_.pendingJobCount(cat);
+    }
+
+    size_t getRunningJobCount(const JobCategory cat) const noexcept {
+        return stats_.runningJobCount(cat);
+    }
+
+    size_t getCompletedJobCount(const JobCategory cat) const noexcept {
+        return stats_.completedJobCount(cat);
+    }
+
+    void waitForAllRealTime() {
+        stats_.waitForAll(JobCategory::RealTime);
+    }
+
+    // 任意カテゴリに対しても待機できるよう汎用版を用意
+    void waitForAll(JobCategory cat) {
+        stats_.waitForAll(cat);
+    }
 
     bool isAbort() {
         return abortFlag.load(std::memory_order_acquire);
@@ -208,13 +307,7 @@ public:
         return nullptr;
     }
 
-    //Taskが持つcategoryに応じて対応のwaitQueueにpushする
-    void pushJobWaitQueue(TaskPtr task);
-
     //TaskPtr pushJobWaitQueue(Job&& job,int degree,JobCategory cat);
-    
-    //まとめてBackGroundJobをpushする用
-    void pushBackGroudGlobalQueue(std::vector<TaskPtr>&& tasks);
 
     //フレーム始めに計算した処理数のBGを各ワーカーごとのBGQueueに割り振る。
     //計算は以下パラメータを使用する。
@@ -228,39 +321,6 @@ public:
     std::chrono::steady_clock::time_point getStartFrameTime() const;
 
 private:
-    void pushRealTimeJobWaitQueue(TaskPtr task);
-
-    //BGJobをglobalBGQueueにセット
-    void pushBackGroudGlobalQueue(TaskPtr task);
-
-    bool pushBottom(ChunkPtr&& chunkPtr, std::unique_ptr<JobQueue>& localQueue, std::unique_ptr<WaitBuf>& waitQueue);
-
-    PopStatus popBottom
-    (size_t queueIndex, std::unique_ptr<JobQueue>& queue);
-
-    StealStatus stealQueues(size_t queueIndex, std::vector<std::unique_ptr<JobQueue>>& stealQueues);
-
-    void pushLocalQueue(std::unique_ptr<JobQueue>&localQueue, std::unique_ptr<WaitBuf>&waitQueue);
-
-    //GlobalBGQueueが空ならNull
-    std::optional<TaskPtr>try_popGlobalBackGroundQueue();
-
-    void run_realTimeQueue(size_t queueIndex);
-
-    void run_backGroundQueue(size_t queueIndex);
-
-    bool pop_and_steal_Queue(size_t queueIndex,std::vector<std::unique_ptr<JobQueue>>&stealQueues,std::function<void()>sub_counterFunc);
-
-    void fallbackWaitQueue(std::unique_ptr<WaitBuf>& waitQueue,ChunkPtr chunkPtr) {
-       waitQueue->push(std::move(chunkPtr));
-    }
-
-    void runChunk(size_t queueIndex,ChunkPtr&& chunkPtr);
-
-    void runJob(size_t queueIndex,TaskPtr&& task);
-
-    void run_while_validQueue(size_t queueIndex);
-
     bool allQueuesEmpty() const;
 
     void addDependent(Task* parent, Task* child) {
@@ -276,15 +336,11 @@ private:
 
     size_t calculatePOPBGJobs(double target_ms, double elapsed_ms,double avgJobTime);
 
-    void sub_realTimeJob_counter();
-
-    void sub_backGroundJob_counter();
-
 private:
     double avg_JobTimeMs = 1.0f;
     double avg_ExecuteJobTime = 0.1;
 
-    std::unique_ptr<ChunkAllocator>allocator;
+    JobStats stats_;
 
     // 時刻
     std::chrono::steady_clock::time_point frameStart;
@@ -295,28 +351,14 @@ private:
     std::vector<TaskPtr>globalBackGroudQueue;
     std::mutex backGroundMutex;
 
-    //バックグラウンドで少しづつ処理される
-    //全ての待機キューを処理時に個数を決めて取り出す。
-    //処理フレームを問わない。
-    //std::vector<std::unique_ptr<WaitQueue<TaskPtr>>>backGroundWaitQueues;
-    std::vector<std::unique_ptr<WaitBuf>>backGroundWaitQueues;
-    std::vector<std::unique_ptr<JobQueue>> backGroundLocalQueue;
+    std::vector<std::unique_ptr<JobQueue>> localQueues;
 
-    //リアルタイムキュー
-    //優先的に処理される
-    //1フレーム以内に処理を保証
-    std::vector<std::unique_ptr<WaitBuf>> realTimeWaitQueues;
-    std::vector<std::unique_ptr<JobQueue>> realTimeLocalQueue;
-
-    std::vector<std::thread> workers;
+    std::vector<std::unique_ptr<IWorker>> workers;
 
     std::atomic<bool> stopFlag;
     
     //現ジョブの総数
     std::atomic<size_t> outstanding{ 0 };
-
-    std::atomic<size_t> realTimeJobCounter;
-    std::atomic<size_t> backGroundCounter;
 
     std::mutex stealMutex;
 

--- a/JobWorker.h
+++ b/JobWorker.h
@@ -1,213 +1,303 @@
 #pragma once
 #include "JobDeque.hpp"
-#include "ChunkAllocator.h"
 
 namespace ECS::JobSystem{
 
-//class JobExecutor {
-//public:
-//    void execute(size_t queueIndex,Chunk&& chunk) {
-//        runChunk(queueIndex,chunk);
-//    }
-//
-//private:
-//    void runJob(size_t queueIndex,TaskPtr& task) {
-//        ASSERT(task && task->job.valid(), "task is invoked in JobQueue!!");
-//
-//        task->job.invoke();
-//
-//        //繋がっているchildの依存カウントを減らしていく
-//        for (TaskPtr child = task->nextDependent; child; child = child->nextDependent) {
-//            if (child->inDegree.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-//                pushJobWaitQueue(child);
-//            }
-//        }
-//
-//        static std::mutex logMutex;
-//
-//        // runJob 内
-//        auto prev = outstanding.fetch_sub(1, std::memory_order_acq_rel);
-//        bool didAllFinish = (prev == 1);
-//
-//        if (didAllFinish) {
-//            std::lock_guard<std::mutex> lk(finishMutex);
-//            finishCv.notify_all();
-//        }
-//
-//        {
-//            std::lock_guard<std::mutex> lk2(logMutex);
-//            if (didAllFinish) {
-//                test::saveLog("[All FINISH] queue=%zu outstanding=%zu", queueIndex, outstanding.load());
-//                std::printf("[All FINISH] queue=%zu outstanding=%zu \n", queueIndex, outstanding.load());
-//            }
-//            else {
-//                test::saveLog("[FINISH] queue=%zu outstanding=%zu", queueIndex, outstanding.load());
-//                std::printf("[FINISH] queue=%zu outstanding=%zu \n", queueIndex, outstanding.load());
-//            }
-//        }
-//    }
-//
-//    void runChunk(size_t queueIndex,Chunk& chunk) {
-//        ASSERT(chunk, "chunkPtr is nullptr!!");
-//
-//        while (true) {
-//            auto idx = chunk->start.fetch_add(1, std::memory_order_acq_rel);
-//            auto end = chunk->count.load(std::memory_order_acquire);
-//
-//            if (idx >= end)
-//                break; // 全部終わった
-//
-//            auto task = std::move(chunk->tasks[idx]);
-//            runJob(queueIndex, std::move(task));
-//        }
-//    }
-//};
+struct JobExecutor {
+    using TaskPtr = intrusive_ptr<Task>;
+
+    template<typename T>
+    void operator()(size_t workerId,T&& chunk) {
+        runChunk(workerId,std::move(chunk));
+    }
+
+private:
+    void runJob(size_t workerId,TaskPtr& task) {
+        ASSERT(task && task->job.valid(), "task is invoked in JobQueue!!");
+
+        task->job.invoke();
+
+        //繋がっているchildの依存カウントを減らしていく
+        for (TaskPtr child = task->nextDependent; child; child = child->nextDependent) {
+            if (child->inDegree.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+                //pushJobWaitQueue(child);
+            }
+        }
+    }
+
+    template<typename T>
+    void runChunk(size_t workerId,T&& chunk) {
+        ASSERT(chunk, "chunkPtr is nullptr!!");
+
+        auto start = chunk.start;
+        auto end = chunk.count;
+
+        for (size_t i = start; i < end; i++) {
+            auto task = chunk.owner->tryGetPtr(i);
+
+            ASSERT(task, "task is nullptr");
+            runJob(workerId, task);
+
+            //デストラクタ呼び出し
+            chunk.owner->destroyAt(i);
+        }
+    }
+};
 
 struct RealTimePolicy{
 
-    template<typename LocalQ,typename StealQs,typename RealQ,typename BgQ,typename Chunk>
-    bool operator()(LocalQ&localQ, StealQs& stealQs,RealQ&rtQ,BgQ&bgQ, Chunk& chunkHandle)
+    template<typename LocalQ, typename StealQs, typename RealTimeTasks, typename BackGroundTasks, typename Chunk>
+    bool operator()(LocalQ& localQ, StealQs& stealQs, RealTimeTasks& rt, BackGroundTasks& bg, Chunk& chunkHandle)
     {
         if(localQ.isAbort()){
             return false;
         }
 
         Chunk chunk;
+        auto& manager = JobManager::Instance();
+
+        size_t takeNum = rt.remainingSlot();
 
         //待機キューから取得
-        while(true){
-            if(!rtQ.try_pop(chunk)||!localQ.pushWithTimeout(chunk,rtQ)) break;
+        std::vector<Chunk> chunks = rt.popMany(takeNum);
+        auto chunks = rt.popMany(takeNum);
+        while (!chunks.empty()) {
+            auto chunk = std::move(chunks.back());
+
+            chunks.pop_back();
+
+            localQ.pushWithTimeout(std::move(chunk), rt);
         }
 
         //realTimeJob処理
-        if (rtQ->getTaskCounter() != 0 && localQ->popOrSteal(stealQs,chunkHandle)) return true;
+        if (manager.pendingJobCount(JobCategory::RealTime) >  0 && localQ->popOrSteal(stealQs,chunkHandle)) return true;
 
-        //realTimeJobのpopもstealも失敗した場合
-        
-        //backGroundJob処理
-        if(bgQ->getTaskCounter() == 0) return false;
-        
-        while (true) {
-            if (!bgQ.try_pop(chunk) || !localQ.pushWithTimeout(chunk, bgQ)) break;
+        takeNum = bg.remainingSlot();
+
+        //待機キューから取得
+        std::vector<Chunk> chunks = bg.popMany(takeNum);
+        auto chunks = bg.popMany(takeNum);
+        while (!chunks.empty()) {
+            auto chunk = std::move(chunks.back());
+
+            chunks.pop_back();
+
+            localQ.pushWithTimeout(std::move(chunk), bg);
         }
         
+        //backGroundJob処理
+        if (manager.pendingJobCount(JobCategory::BackGround) <= 0) return false;
+
         return localQ->popOrSteal(stealQs,chunkHandle);
     }
 
     static constexpr size_t realTimeCap = 20'000;
     static constexpr size_t backGroundCap = 1'000;
+
+    static constexpr size_t realTimeChunkSize = 512;
+    static constexpr size_t backGroundChunkSize = 512;
 
     static constexpr size_t localQueueCap = 1024;
 };
 
-struct BackGroundPolicy {
+//struct BackGroundPolicy {
+//
+//    template<typename LocalQ,typename StealQs,typename RealTimeTasks, typename BackGroundTasks, typename Chunk>
+//    bool operator()(LocalQ& localQ, StealQs& stealQs, RealTimeTasks& rt, BackGroundTasks& bg, Chunk& chunkHandle)
+//    {
+//        if (localQ.isAbort()) {
+//            return false;
+//        }
+//
+//        Chunk chunk;
+//        auto& manager = JobManager::Instance();
+//
+//        size_t takeNum = rt.remainingSlot();
+//
+//        //待機キューから取得
+//        while (true) {
+//            bg.popMany(takeNum);
+//            if (! || !localQ.pushWithTimeout(chunk, bgQ)) break;
+//        }
+//
+//        //backGroundJob処理
+//        if (manager.pendingJobCount(JobCategory::BackGround) > 0 && localQ.popOrSteal(stealQs, chunkHandle){
+//            return true;
+//        }
+//
+//        //backGroundJobのpopもstealも失敗した場合
+//        while (true) {
+//            if (!rtQ.try_pop(chunk) || !localQ.pushWithTimeout(chunk, rtQ)) break;
+//        }
+//
+//        //realTimeJob処理
+//        if (manager.pendingJobCount(JobCategory::RealTime) == 0) return false;
+//
+//        return localQ.popOrSteal(stealQs,chunkHandle);
+//    }
+//
+//    static constexpr size_t realTimeCap = 20'000;
+//    static constexpr size_t backGroundCap = 1'000;
+//
+//    static constexpr size_t realTimeChunkSize = 512;
+//    static constexpr size_t backGroundChunkSize = 512;
+//
+//    static constexpr size_t localQueueCap = 1024;
+//};
 
-    template<typename LocalQ,typename StealQs,typename RealQ, typename BgQ, typename Chunk>
-    bool operator()(LocalQ& localQ, StealQs& stealQs,RealQ& rtQ, BgQ& bgQ, Chunk& chunkHandle)
-    {
-        if (localQ.isAbort()) {
-            return false;
-        }
+using TaskPtr = intrusive_ptr<Task>;
 
-        Chunk chunk;
+class JobStats;
 
-        //待機キューから取得
-        while (true) {
-            if (!bgQ.try_pop(chunk) || !localQ.pushWithTimeout(chunk, bgQ)) break;
-        }
+//タスクキュー
+template<typename Policy>
+using RealTimeStorageType= TaskStorage<TaskPtr, Policy::realTimeCap, Policy::realTimeChunkSize>;
 
-        //backGroundJob処理
-        if (bgQ->getTaskCounter() != 0 && localQ->popOrSteal(stealQs,chunkHandle)) return true;
+template<typename Policy>
+using BackGroundStorageType = TaskStorage<TaskPtr, Policy::backGroundCap, Policy::backGroundChunkSize>;
 
-        //backGroundJobのpopもstealも失敗した場合
+class IWorker {
+public:
 
-        //realTimeJob処理
-        if (rtQ->getTaskCounter() == 0) return false;
+    virtual ~IWorker() = default;
 
-        while (true) {
-            if (!rtQ.try_pop(chunk) || !localQ.pushWithTimeout(chunk, rtQ)) break;
-        }
+    virtual TaskPtr schedule(JobCategory cat,
+        Job&& job,
+        int degree) = 0;
 
-        return localQ->popOrSteal(stealQs,chunkHandle);
-    }
+    virtual TaskPtr schedule(JobCategory cat,
+        Job&& job,
+        int degree,
+        std::vector<TaskPtr>& deps) = 0;
 
-    static constexpr size_t realTimeCap = 20'000;
-    static constexpr size_t backGroundCap = 1'000;
-
-    static constexpr size_t localQueueCap = 1024;
+    virtual TaskPtr schedule(JobCategory cat,
+        TaskPtr&&task) = 0;
 };
 
 template<
-    typename ChunkAllocator,
-    typename WorkerPolicy = RealTimePolicy
+    typename WorkerPolicy = RealTimePolicy,
+    typename ExecuteFunc = JobExecutor
     >
-class Worker {
-    static constexpr std::size_t realTimeCap = WorkerPolicy::realTimeCap;
-    static constexpr std::size_t backGroundCap = WorkerPolicy::backGroundCap;
+class Worker : public IWorker{
     static constexpr std::size_t localQueueCap = WorkerPolicy::localQueueCap;
 
-    using Chunk = ChunkAllocator::Chunk;
-
-    using ChunkHandle = ChunkAllocator::ChunkHandle;
-
-    using JobQueue = Debug::DebugJobQueue<JobDeque<Chunk>>;
+    using JobQueue = Debug::DebugJobQueue<JobDeque<SliceChunk>>;
 
     using LocalQPtr = std::unique_ptr<JobQueue>*;
 
-    //タスクキュー
-    using RealTaskQueue = TaskQueue<TaskPtr, realTimeCap, ChunkAllocator>;
-    using BackGroundTaskQueue = TaskQueue<TaskPtr, backGroundCap, ChunkAllocator>;
+    using RealTimeTaskStorage = RealTimeStorageType<WorkerPolicy>;
+
+    using BackGroundTaskStorage = BackGroundStorageType<WorkerPolicy>;
 
 public:
-    Worker(size_t id,ChunkAllocator* allocator,LocalQPtr queues);
+    //localQやtaskQの初期化処理など
+    Worker(size_t id,LocalQPtr queues,JobStats&stats);
 
-    ~Worker();
+    //残っているtaskの処理
+    ~Worker() override;
 
-    bool pushJob(Job&&job);
+    TaskPtr schedule(JobCategory cat, Job&& job, int degree) override;
 
-    //bool popOrSteal(ChunkHandle* chunkHandle);
+    TaskPtr schedule(JobCategory cat,Job&& job, int degree, std::vector<TaskPtr>&deps) override;
+
+    TaskPtr schedule(JobCategory cat,TaskPtr&&task) override;
 
 private:
-    run();
+    //localQueueのpop、stealを行う。
+    void run();
 
-    stop();
+    //全てのたまっているtaskを処理し、終了
+    void stop();
+
+    void DebugLog(JobCategory cat);
+
+    std::string jobCategoryToString(JobCategory cat);
 
 private:
+    //localQのインデックス
     const size_t workerId;
+    JobStats& stats_;
+    WorkerPolicy policy_;
+
     std::thread     thread_;
     std::atomic<bool> running = false;
 
     //タスクキュー
-    std::unique_ptr<RealTaskQueue>realTimeTaskQueue;
-    std::unique_ptr<BackGroundTaskQueue>backGroundTaskQueue;
+    std::unique_ptr<RealTimeTaskStorage>realTimeTaskStorage;
+    std::unique_ptr<BackGroundTaskStorage>backGroundTaskStorage;
 
     LocalQPtr localQueue;
 
     LocalQPtr stealQueues;
-
-    ChunkAllocator* allocator_;
 };
 
-template<typename ChunkAllocator, typename WorkerPolicy>
-inline Worker<ChunkAllocator, WorkerPolicy>::Worker(size_t id, ChunkAllocator* allocator,LocalQPtr queues) : workerId(id), allocator_(allocator), localQueue(queues[id]), stealQueues(queues),running(true),thread_([this]{run();})
+template<typename WorkerPolicy, typename ExecuteFunc>
+inline Worker<WorkerPolicy, ExecuteFunc>::Worker(size_t id,LocalQPtr queues,JobStats&stats) : workerId(id), stats_(stats),localQueue(queues[id]), stealQueues(queues),running(true),thread_([this]{run();})
 {
-    realTimeTaskQueue = std::make_unique<RealTaskQueue>(allocator.get());
-    backGroundTaskQueue = std::make_unique<BackGroundTaskQueue>(allocator.get());
+    realTimeTaskStorage = std::make_unique<RealTimeTaskStorage>();
+    backGroundTaskStorage = std::make_unique<BackGroundTaskStorage>();
 }
 
-template<typename ChunkAllocator, typename WorkerPolicy>
-inline Worker<ChunkAllocator, WorkerPolicy>::~Worker()
+template<typename WorkerPolicy,typename ExecuteFunc>
+inline Worker<WorkerPolicy, ExecuteFunc>::~Worker()
 {
     stop();
+        
     if (thread_.joinable()) {
         thread_.join();
     }
 }
 
-template<typename ChunkAllocator, typename WorkerPolicy>
-inline bool Worker<ChunkAllocator, WorkerPolicy>::pushJob(Job&& job)
+template<typename WorkerPolicy, typename ExecuteFunc>
+inline TaskPtr Worker<WorkerPolicy, ExecuteFunc>::schedule(JobCategory cat, Job&& job, int degree)
 {
-    return false;
+
+    //カウント
+    stats_.onEnqueued(cat,1);
+    switch (cat)
+    {
+    case JobCategory::RealTime:
+        return realTimeTaskStorage->pushOne(std::move(job), degree, cat);
+    case JobCategory::BackGround:
+        return backGroundTaskStorage->pushOne(std::move(job), degree, cat);
+    }
+
+    return nullptr;
+}
+
+template<typename WorkerPolicy,typename ExecuteFunc>
+inline TaskPtr Worker<WorkerPolicy, ExecuteFunc>::schedule(JobCategory cat,Job&& job, int degree, std::vector<TaskPtr>&deps)
+{
+    //deps処理
+
+    //カウント
+    stats_.onEnqueued(cat,1);
+    switch (cat)
+    {
+        case JobCategory::RealTime:
+            return realTimeTaskStorage->pushOne(std::move(job),degree,cat);
+        case JobCategory::BackGround:
+            return backGroundTaskStorage->pushOne(std::move(job), degree, cat);
+    }
+
+    return nullptr;
+}
+
+template<typename WorkerPolicy, typename ExecuteFunc>
+inline TaskPtr Worker<WorkerPolicy, ExecuteFunc>::schedule(JobCategory cat, TaskPtr&& task)
+{
+    //カウント
+    stats_.onEnqueued(cat,1);
+
+    switch (cat)
+    {
+    case JobCategory::RealTime:
+        return realTimeTaskStorage->pushOne(std::move(task));
+    case JobCategory::BackGround:
+        return backGroundTaskStorage->pushOne(std::move(task));
+    }
+
+    return nullptr;
 }
 
 //template<typename ChunkAllocator, typename WorkerPolicy>
@@ -240,28 +330,86 @@ inline bool Worker<ChunkAllocator, WorkerPolicy>::pushJob(Job&& job)
 //    }
 //
 //    std::this_thread::yield();
-//    return false;
+//    return false
+// 
 //}
 
-template<typename ChunkAllocator, typename WorkerPolicy>
-inline Worker<ChunkAllocator, WorkerPolicy>::run()
+template<typename WorkerPolicy, typename ExecuteFunc>
+inline void Worker<WorkerPolicy,ExecuteFunc>::run()
 {
-    
-    ChunkHandle chunkHandle = nullptr;
-    while (running_.load(std::memory_order_relaxed)) {
+    while (running.load(std::memory_order_relaxed)) {
 
-        if(WorkerPolicy(localQueue,stealQueues,realTimeTaskQueue, backGroundTaskQueue, chunkHandle){
-            //jobExecuter->runChunk(std::move(chunkHandle));
+        SliceChunk slice;
+        if(policy_(localQueue,stealQueues,realTimeTaskStorage, backGroundTaskStorage, slice)){
+            //取得失敗なので次のループへ
+            if(slice.count == 0) continue;
+
+            JobCategory cat = slice.owner->tryGetPtr(slice.start)->category;
+            size_t count = slice.count;
+
+            //Chunk実行
+            stats_.onDequeued(cat, count);
+            stats_.onStart(cat, count);
+            ExecuteFunc(workerId,std::move(slice));
+            stats_.onFinish(cat, count);
+
+            //ログ出力
+            DebugLog(cat);
         }
-
-        chunkHandle = nullptr;
     }
 }
 
-template<typename ChunkAllocator, typename WorkerPolicy>
-inline Worker<ChunkAllocator, WorkerPolicy>::stop()
+template<typename WorkerPolicy, typename ExecuteFunc>
+inline void Worker<WorkerPolicy,ExecuteFunc>::stop()
 {
-    running_.store(false, std::memory_order_relaxed);
+    running.store(false, std::memory_order_relaxed);
+
+    while(stats_.notCompletedJobCount(JobCategory::RealTime) > 0 && stats_.notCompletedJobCount(JobCategory::BackGround) > 0){
+        SliceChunk slice;
+
+        if (policy_(localQueue, stealQueues, realTimeTaskStorage, backGroundTaskStorage, slice)) {
+            if (slice.count == 0) continue;
+
+            JobCategory cat = slice.owner->tryGetPtr(slice.start)->category;
+            size_t count = slice.count;
+
+            //Chunk実行
+            stats_.onDequeued(cat, count);
+            stats_.onStart(cat, count);
+            ExecuteFunc(workerId, std::move(slice));
+            stats_.onFinish(cat, count);
+
+            //ログ出力
+            DebugLog(cat);
+        }
+    }
+}
+
+template<typename WorkerPolicy, typename ExecuteFunc>
+inline void Worker<WorkerPolicy,ExecuteFunc>::DebugLog(JobCategory cat)
+{
+    static std::mutex logMutex;
+
+    std::lock_guard<std::mutex>(logMutex);
+
+    auto notCompletedCount = stats_.notCompletedJobCount();
+    test::saveLog("[FINISH] queue=%zu outstanding=%zu", workerId, notCompletedCount);
+    std::printf("[FINISH] queue=%zu outstanding=%zu \n", workerId, notCompletedCount);
+
+    if(notCompletedCount == 0){
+        test::saveLog("All FINISH : %s", jobCategoryToString(cat));
+        std::printf("All FINISH : %s", jobCategoryToString(cat));
+    }
+}
+
+template<typename WorkerPolicy, typename ExecuteFunc>
+inline std::string Worker<WorkerPolicy,ExecuteFunc>::jobCategoryToString(JobCategory cat)
+{
+    switch (cat) {
+    case JobCategory::RealTime:   return "RealTime";
+    case JobCategory::BackGround: return "BackGround";
+    default:    return "Unknown";
+    }
 }
 
 }

--- a/TaskQueue.h
+++ b/TaskQueue.h
@@ -1,195 +1,384 @@
 #pragma once
-#include "ChunkAllocator.h"
+#include "taskPtr.hpp"
 
 namespace ECS::JobSystem{
 
-class ITaskQueue {
+class ITaskQueue {};
+
+// ディスクリプタ：バッファ上の [start, start+count) を表す
 
 
-};
+////T : 内部で保持する型
+////Capacity : WaitJobBufferがためることができるChunkの最大数
+////ChunkAllocator : Chunkを生成するクラス。
+//template <typename T, size_t Capacity, typename ChunkAllocator>
+//class TaskQueue : ITaskQueue{
+//    using Chunk = typename ChunkAllocator::Chunk;
+//    using ChunkHandle = typename ChunkAllocator::ChunkHandle;
+//
+//    // ディスクリプタ：バッファ上の [start, start+count) を表す
+//    struct SliceChunk {
+//        size_t start;
+//        size_t count;
+//
+//    };
+//
+//public:
+//    TaskQueue(ChunkAllocator* alloc) : allocator(alloc) {}
+//
+//    // マルチスレッド(Job制作用)
+//    void push(const T& value) {
+//        std::unique_lock<std::mutex> lock(mutex_);
+//
+//        // 全体のタスク数が Capacity 未満になるまで待つ
+//        not_full_.wait(lock, [this] { return size_.load(std::memory_order_acquire) < Capacity; });
+//
+//        if (!buffer_[tail_]) {
+//            buffer_[tail_] = allocator->allocateHandle();
+//            buffer_[tail_]->count = 0;
+//        }
+//
+//        // 現在のチャンクにタスクを書き込む
+//        auto& chunk = buffer_[tail_];
+//        size_t idx = chunk->count.fetch_add(1, std::memory_order_relaxed);
+//        chunk->tasks[idx] = std::move(value);
+//
+//        //全体のタスク数を記録
+//        size_.fetch_add(1, std::memory_order_release);
+//
+//        //満タンになった場合、tailを進める
+//        if (buffer_[tail_]->full()) {
+//            tail_ = (tail_ + 1) % Capacity;
+//        }
+//
+//        lock.unlock();
+//        not_empty_.notify_one();
+//    }
+//
+//    //マルチスレッド
+//    TaskPtr push(Job&& job,int degree,std::vector<TaskPtr>deps) {
+//        std::unique_lock<std::mutex> lock(mutex_);
+//
+//        // 全体のタスク数が Capacity 未満になるまで待つ
+//        not_full_.wait(lock, [this] { return size_.load(std::memory_order_acquire) < Capacity; });
+//
+//        if (!buffer_[tail_]) {
+//            buffer_[tail_] = ChunkPtr(
+//                allocator->allocate(),
+//                ChunkDeleter{ allocator }
+//            );
+//            buffer_[tail_]->count = 0;
+//        }
+//
+//        // 現在のチャンクにタスクを書き込む
+//        auto& chunk = buffer_[tail_];
+//        size_t idx = chunk->count.fetch_add(1, std::memory_order_relaxed);
+//        chunk->tasks[idx] = ;
+//
+//        //全体のタスク数を記録
+//        size_.fetch_add(1, std::memory_order_release);
+//
+//        //満タンになった場合、tailを進める
+//        if (buffer_[tail_]->full()) {
+//            tail_ = (tail_ + 1) % Capacity;
+//        }
+//
+//        lock.unlock();
+//        not_empty_.notify_one();
+//    }
+//
+//    void enqueue(ChunkHandle&& value) {
+//        std::unique_lock<std::mutex> lock(mutex_);
+//
+//        size_t taskSize = value->count - value->start;
+//
+//        not_full_.wait(lock, [this, &taskSize] { return (size_.load(std::memory_order_acquire) + taskSize) < Capacity; });
+//
+//        ASSERT(value, "WaitJobBuffer push ChunkPtr&&value is nullptr");
+//
+//        size_.fetch_add(taskSize, std::memory_order_release);
+//
+//        if (buffer_[tail_] == nullptr || buffer_[tail_]->empty()) {
+//            //nullのスロットに直接代入
+//            buffer_[tail_] = std::move(value);
+//            if (buffer_[tail_]->full()) {
+//                tail_ = (tail_ + 1) % Capacity;
+//            }
+//            lock.unlock();
+//            not_empty_.notify_one();
+//
+//            return;
+//        }
+//
+//        //not_full_.wait(lock, [this] { return size_.load(std::memory_order_acquire) < Capacity-1; });
+//        //次のスロットに入れる。
+//        tail_ = (tail_ + 1) % Capacity;
+//        buffer_[tail_] = std::move(value);
+//
+//        //入れたChunkが満タンなら
+//        if (buffer_[tail_]->full()) {
+//            tail_ = (tail_ + 1) % Capacity;
+//        }
+//
+//        lock.unlock();
+//        not_empty_.notify_one();
+//    }
+//
+//    bool try_pop(ChunkHandle& chunkPtr) {
+//        if (size_.load(std::memory_order_acquire) == 0) {
+//            return false;
+//        }
+//
+//        std::lock_guard<std::mutex> lock(mutex_);
+//
+//        if (size_.load(std::memory_order_acquire) == 0) {
+//            return false;
+//        }
+//
+//        ASSERT(buffer_[head_], "buffer_[head_] is nullptr");
+//        chunkPtr = std::move(buffer_[head_]);
+//
+//        buffer_[head_] = nullptr;
+//
+//        if (tail_ > head_) {
+//            head_ = (head_ + 1) % Capacity;
+//        }
+//
+//        size_t taskSize = chunkPtr->count.load() - chunkPtr->start.load();
+//        size_.fetch_sub(taskSize, std::memory_order_release);
+//
+//        ASSERT(size_ >= 0, "WaitJobBuffer is size_ < 0");
+//
+//        not_full_.notify_one();
+//        return true;
+//    }
+//
+//    // pop（単一スレッド専用）
+//    //bool try_pop(T& value) {
+//    //    if (size_.load(std::memory_order_acquire) == 0) {
+//    //        return false;
+//    //    }
+//
+//    //    //value = std::move(buffer_[head_]);
+//    //    head_ = (head_ + 1) % Capacity;
+//    //    size_.fetch_sub(1, std::memory_order_release);
+//    //   
+//    //    not_full_.notify_one();
+//    //    return true;
+//    //}
+//
+//    bool wait_and_pop(ChunkHandle& chunkPtr) {
+//        std::unique_lock<std::mutex> lock(mutex_);
+//
+//        not_empty_.wait(lock, [this] { return size_.load(std::memory_order_acquire) > 0; });
+//
+//        chunkPtr = std::move(buffer_[head_]);
+//        buffer_[head_] = nullptr;
+//
+//        head_ = (head_ + 1) % Capacity;
+//
+//        size_t taskSize = chunkPtr->count.load() - chunkPtr->start.load();
+//        size_.fetch_sub(taskSize, std::memory_order_release);
+//
+//        lock.unlock();
+//        not_full_.notify_one();
+//        return true;
+//    }
+//
+//private:
+//    ChunkAllocator* allocator;
+//    //std::array<ChunkHandle, Capacity> buffer_{};
+//    std::unique_ptr<Storage[]> buffer_;
+//
+//    size_t head_ = 0, tail_ = 0;
+//    //全体のタスク数
+//    std::atomic<size_t> size_{ 0 };
+//    std::atomic<size_t> chunkSize_{ 0 };
+//
+//    std::mutex mutex_;
+//    std::condition_variable not_empty_;
+//    std::condition_variable not_full_;
+//};
 
-//T : 内部で保持する型
-//Capacity : WaitJobBufferがためることができるChunkの最大数
-//ChunkAllocator : Chunkを生成するクラス。
-template <typename T, size_t Capacity, typename ChunkAllocator>
-class TaskQueue : ITaskQueue{
-    using Chunk = typename ChunkAllocator::Chunk;
-    using ChunkHandle = typename ChunkAllocator::ChunkHandle;
+
+// in-place 構築用の大規模バッファ
+class TaskArena {
+    using TaskPtr = intrusive_ptr<Task>;
+
+    std::vector<std::optional<TaskPtr>> buffer_;
+    std::atomic<size_t> writePos_{ 0 };
 
 public:
-    TaskQueue(ChunkAllocator* alloc) : allocator(alloc) {}
-
-    // マルチスレッド(Job制作用)
-    void push(const T& value) {
-        std::unique_lock<std::mutex> lock(mutex_);
-
-        // 全体のタスク数が Capacity 未満になるまで待つ
-        not_full_.wait(lock, [this] { return size_.load(std::memory_order_acquire) < Capacity; });
-
-        if (!buffer_[tail_]) {
-            buffer_[tail_] = allocator->allocateHandle();
-            buffer_[tail_]->count = 0;
-        }
-
-        // 現在のチャンクにタスクを書き込む
-        auto& chunk = buffer_[tail_];
-        size_t idx = chunk->count.fetch_add(1, std::memory_order_relaxed);
-        chunk->tasks[idx] = std::move(value);
-
-        //全体のタスク数を記録
-        size_.fetch_add(1, std::memory_order_release);
-
-        //満タンになった場合、tailを進める
-        if (buffer_[tail_]->full()) {
-            tail_ = (tail_ + 1) % Capacity;
-        }
-
-        lock.unlock();
-        not_empty_.notify_one();
+    TaskArena(size_t maxTasks){
+        // 必ず MaxTasks の slot を用意しておく
+        buffer_.resize(maxTasks);
     }
 
-    // マルチスレッド
-    //TaskPtr push(Job job,int degree,std::vector<TaskPtr>deps) {
-    //    std::unique_lock<std::mutex> lock(mutex_);
+    // チャンク単位（ここでは 1～N）の先頭インデックスを確保
+    size_t reserve(size_t count) {
+        return writePos_.fetch_add(count, std::memory_order_relaxed);
+    }
 
-    //    // 全体のタスク数が Capacity 未満になるまで待つ
-    //    not_full_.wait(lock, [this] { return size_.load(std::memory_order_acquire) < Capacity; });
+    template<typename... Args>
+    TaskPtr constructAt(size_t idx, Args&&... args) {
+        buffer_[idx].emplace(std::forward<Args>(args)...);
+        return *buffer_[idx];
+    }
 
-    //    if (!buffer_[tail_]) {
-    //        buffer_[tail_] = ChunkPtr(
-    //            allocator->allocate(),
-    //            ChunkDeleter{ allocator }
-    //        );
-    //        buffer_[tail_]->count = 0;
-    //    }
+    TaskPtr push(size_t idx,TaskPtr&& task) {
+        buffer_[idx] = std::move(task);
+        return *buffer_[idx];
+    }
 
-    //    // 現在のチャンクにタスクを書き込む
-    //    auto& chunk = buffer_[tail_];
-    //    size_t idx = chunk->count.fetch_add(1, std::memory_order_relaxed);
-    //    chunk->tasks[idx] = std::move(value);
+    //破棄
+    void destroyAt(size_t idx) {
+        buffer_[idx].reset(); 
+    }
 
-    //    //全体のタスク数を記録
-    //    size_.fetch_add(1, std::memory_order_release);
+    TaskPtr* tryGetPtr(size_t idx) noexcept {
+        return (buffer_[idx])
+            ? std::addressof(*buffer_[idx])
+            : nullptr;
+    }
 
-    //    //満タンになった場合、tailを進める
-    //    if (buffer_[tail_]->full()) {
-    //        tail_ = (tail_ + 1) % Capacity;
-    //    }
+    /*std::optional<TaskPtr&> tryGet(size_t idx) noexcept {
+        auto& slot = buffer_[idx];
 
-    //    lock.unlock();
-    //    not_empty_.notify_one();
-    //}
+        if (!slot.has_value()) return std::nullopt;
 
-    void push(ChunkHandle&& value) {
-        std::unique_lock<std::mutex> lock(mutex_);
+        return *slot;  
+    }
 
-        size_t taskSize = value->count - value->start;
+    std::optional<const TaskPtr&> tryGet(size_t idx) const noexcept {
+        auto& slot = buffer_[idx];
 
-        not_full_.wait(lock, [this, &taskSize] { return (size_.load(std::memory_order_acquire) + taskSize) < Capacity; });
+        if (!slot.has_value()) return std::nullopt;
 
-        ASSERT(value, "WaitJobBuffer push ChunkPtr&&value is nullptr");
+        return *slot;
+    }*/
+};
 
-        size_.fetch_add(taskSize, std::memory_order_release);
+struct SliceChunk {
+    size_t start;
+    size_t count;
+    TaskArena* owner;
+};
 
-        if (buffer_[tail_] == nullptr || buffer_[tail_]->empty()) {
-            //nullのスロットに直接代入
-            buffer_[tail_] = std::move(value);
-            if (buffer_[tail_]->full()) {
-                tail_ = (tail_ + 1) % Capacity;
-            }
-            lock.unlock();
-            not_empty_.notify_one();
+template<typename T, size_t MaxTasks,size_t MaxSliceSize>
+class TaskStorage {
+    using TaskArena = TaskArena;
+    std::unique_ptr<TaskArena> arena;
+    // チャンク記録用の軽量 MPMC キュー等を用意しておく
+    std::deque<SliceChunk> sliceDeque;
 
+public:
+    TaskStorage(){
+        arena = std::make_unique<TaskArena>(MaxTasks);
+    }
+
+    /*void pushMany(std::vector<Job>& jobs) {
+        auto count = jobs.size();
+        size_t start = arena.reserveChunk(count);
+
+        for (size_t i = 0; i < count; ++i) {
+            new (arena.ptr(start + i))
+                T(std::move(jobs[i]));
+        }
+
+        push(count);
+    }*/
+
+    void enqueue(SliceChunk&& slice){
+        if(sliceDeque.back().count == 0){
+            sliceDeque.back() = std::move(slice);
             return;
         }
 
-        //not_full_.wait(lock, [this] { return size_.load(std::memory_order_acquire) < Capacity-1; });
-        //次のスロットに入れる。
-        tail_ = (tail_ + 1) % Capacity;
-        buffer_[tail_] = std::move(value);
-
-        //入れたChunkが満タンなら
-        if (buffer_[tail_]->full()) {
-            tail_ = (tail_ + 1) % Capacity;
-        }
-
-        lock.unlock();
-        not_empty_.notify_one();
+        sliceDeque.push_back(std::move(slice));
     }
 
-    bool try_pop(ChunkHandle& chunkPtr) {
-        if (size_.load(std::memory_order_acquire) == 0) {
-            return false;
-        }
+    T pushOne(Job&& job,int degree,JobCategory cat) {
+        // (A) バッファを 1 要素分確保
+        size_t start = arena->reserve(1);
 
-        std::lock_guard<std::mutex> lock(mutex_);
+        auto result = arena->constructAt(start, new Task(std::move(job), degree, cat));
 
-        if (size_.load(std::memory_order_acquire) == 0) {
-            return false;
-        }
+        push(start,1);
 
-        ASSERT(buffer_[head_], "buffer_[head_] is nullptr");
-        chunkPtr = std::move(buffer_[head_]);
-
-        buffer_[head_] = nullptr;
-
-        if (tail_ > head_) {
-            head_ = (head_ + 1) % Capacity;
-        }
-
-        size_t taskSize = chunkPtr->count.load() - chunkPtr->start.load();
-        size_.fetch_sub(taskSize, std::memory_order_release);
-
-        ASSERT(size_ >= 0, "WaitJobBuffer is size_ < 0");
-
-        not_full_.notify_one();
-        return true;
+        return result;
     }
 
-    // pop（単一スレッド専用）
-    //bool try_pop(T& value) {
-    //    if (size_.load(std::memory_order_acquire) == 0) {
-    //        return false;
-    //    }
+    T pushOne(T&&task) {
+        // (A) バッファを 1 要素分確保
+        size_t start = arena->reserve(1);
 
-    //    //value = std::move(buffer_[head_]);
-    //    head_ = (head_ + 1) % Capacity;
-    //    size_.fetch_sub(1, std::memory_order_release);
-    //   
-    //    not_full_.notify_one();
-    //    return true;
-    //}
+        auto result = arena->push(start,std::move(task));
 
-    bool wait_and_pop(ChunkHandle& chunkPtr) {
-        std::unique_lock<std::mutex> lock(mutex_);
+        push(start, 1);
 
-        not_empty_.wait(lock, [this] { return size_.load(std::memory_order_acquire) > 0; });
+        return result;
+    }
 
-        chunkPtr = std::move(buffer_[head_]);
-        buffer_[head_] = nullptr;
+    SliceChunk popOne(){
+        if(empty()){
+            return {0,0};
+        }
 
-        head_ = (head_ + 1) % Capacity;
+        return sliceDeque.pop_front();
+    }
 
-        size_t taskSize = chunkPtr->count.load() - chunkPtr->start.load();
-        size_.fetch_sub(taskSize, std::memory_order_release);
+    std::vector<SliceChunk> popMany(size_t maxCount) {
+        ASSERT(maxCount > 0,"Slice popMany() maxCount under zero");
 
-        lock.unlock();
-        not_full_.notify_one();
-        return true;
+        std::vector<SliceChunk> out;
+
+        size_t curTaskCount = 0;
+        //フルスライスを取り出す
+        while(sliceDeque.size() > 1) {
+            auto& c = sliceDeque.front();
+
+            //取得するタスク数を超えた場合
+            if(curTaskCount + c.count > maxCount){
+                break;
+            }
+
+            curTaskCount += c.count;
+            out.push_back(c);
+            sliceDeque.pop_front();
+        }
+
+        // フルスライスが１つも無ければ、バックを返す
+        if (out.empty() && !sliceDeque.empty() && sliceDeque.back().count > 0) {
+            ASSERT(sliceDeque.back().count > maxCount,"back() size over");
+
+            out.push_back(sliceDeque.back());
+            sliceDeque.pop_back();
+        }
+
+        return out;
+    }
+
+    bool empty(){
+        return sliceDeque.empty()||sliceDeque.front().count == 0;
     }
 
 private:
-    ChunkAllocator* allocator;
-    std::array<ChunkHandle, Capacity> buffer_{};
+    void push(size_t start,size_t count){
+        if(sliceDeque.empty()){
+            sliceDeque.push_back({start,0});
+        }
 
-    size_t head_ = 0, tail_ = 0;
-    //全体のタスク数
-    std::atomic<size_t> size_{ 0 };
-    std::atomic<size_t> chunkSize_{ 0 };
+        size_t newSize = sliceDeque.back().count + count;
 
-    std::mutex mutex_;
-    std::condition_variable not_empty_;
-    std::condition_variable not_full_;
+        //最大値を超えた場合
+        if (newSize >= MaxSliceSize) {
+            sliceDeque.back().count = MaxSliceSize;
+            size_t newStart = sliceDeque.back().start + MaxSliceSize;
+            sliceDeque.push_back({ newStart,newSize - MaxSliceSize ,arena.get()});
+        }
+        else {
+            sliceDeque.back().count = newSize;
+        }
+    }
 };
-
 }

--- a/ecsTest.h
+++ b/ecsTest.h
@@ -147,12 +147,12 @@ TEST_CASE_PRIORITY(test_jobSystem) {
 		//busyWait(std::chrono::milliseconds(2));
 	}
 
-	jm.waitForAllRealTimeJob();
+	jm.waitForAllRealTime();
 	std::printf("realTime job finished!! \n");
-	jm.popGlobalBackGroundQueue();
+	//jm.popGlobalBackGroundQueue();
 
 	// 4) すべてのジョブ完了を待機
-	jm.waitForAll();
+	//jm.waitForAll();
 
 	assertTrue(jm.checkRanAllJobInJobQueues(), "JobSystem Valid Test");
 	assertTrue(!jm.isAbort(),"JobSystem Work Test");
@@ -215,7 +215,7 @@ TEST_CASE_PRIORITY(test_particalJobSystem){
 	}
 
 	// 4) すべてのジョブ完了を待機
-	js.waitForAllRealTimeJob();
+	js.waitForAllRealTime();
 
 	auto globalEnd = ECS::JobSystem::now();
 	int  globalDuration = ECS::JobSystem::duration(globalStart, globalEnd);

--- a/taskPtr.hpp
+++ b/taskPtr.hpp
@@ -12,6 +12,8 @@
 
 namespace ECS::JobSystem{
 
+enum class JobCategory { RealTime, BackGround, Num };
+
 #define REFLECT_FIELDS(Type, ...)                                  \
   static constexpr auto field_ptrs()                                \
   { return std::make_tuple(__VA_ARGS__); }
@@ -107,11 +109,6 @@ public:
     explicit operator bool() const noexcept = delete;
 };
 
-enum class JobCategory : uint8_t {
-    RealTime,
-    BackGround
-};
-
 struct Task {
     Job job;
     std::atomic<int>   inDegree{ 0 };
@@ -132,7 +129,8 @@ struct Task {
 
     void release() {
         if (refCount.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-            delete this;
+
+           delete this;
         }
     }
 
@@ -586,10 +584,9 @@ struct IJob : std::enable_shared_from_this<Derived> {
         // ƒ[ƒJ[”•ª‚¾‚¯ Task ‚ğì¬‚µ‚Ä“o˜^
         auto work = [ctx]() { workerEntry(ctx); };
 
-        auto task = new Task(Job(std::move(work)), 0,cat);
-        TaskPtr taskPtr{ std::move(task) };
+        Job job(std::move(work));
 
-        JobManager::Instance().pushJobWaitQueue(taskPtr);
+        auto taskPtr = JobManager::Instance().schedule(cat,std::move(job),0);
 
         return std::make_pair(taskPtr, future);
     }
@@ -610,21 +607,19 @@ struct IJob : std::enable_shared_from_this<Derived> {
         // ƒ[ƒJ[”•ª‚¾‚¯ Task ‚ğì¬‚µ‚Ä“o˜^
         auto work = [ctx]() { workerEntry(ctx); };
 
-        //Job job(std::move(work));
+        Job job(std::move(work));
 
-        auto task = new Task(Job(std::move(work)), 0,cat);
-        TaskPtr taskPtr{ std::move(task) };
+        /*auto task = new Task(Job(std::move(work)), 0,cat);
+        TaskPtr taskPtr{ std::move(task) };*/
 
-        for (auto& d : deps) {
+       /* for (auto& d : deps) {
             std::lock_guard<std::mutex> lk(d->taskMutex);
             if (d && d->job.valid()) {
                 taskPtr.get()->addDependent(d.get());
             }
-        }
+        }*/
 
-        if (taskPtr->inDegree.load() == 0) {
-            JobManager::Instance().pushJobWaitQueue(taskPtr);
-        }
+        auto taskPtr = JobManager::Instance().schedule(cat,std::move(job),0);
 
         return std::make_pair(taskPtr,future);
     }


### PR DESCRIPTION
## 変更内容
- `struct SliceChunk {
    size_t start;
    size_t count;
    TaskArena* owner;
};

template<typename T, size_t MaxTasks,size_t MaxSliceSize>
class TaskStorage {
    using TaskArena = TaskArena;
    //全タスクを連続配置で保持
    std::unique_ptr<TaskArena> arena;
    // チャンク記録用の軽量 MPMC キュー等を用意しておく
    std::deque<SliceChunk> sliceDeque;

 arena->tryGetPtr(idx)で連続メモリの中からタスクを取得
`